### PR TITLE
Add logging, website with log history

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+## Log history website
+
+To start the Node server, run the following commands.
+
+```
+cd dist
+node index.js
+```
+
+The website will now be accessible at [localhost:3000](localhost:3000).

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,33 @@
+const fs = require('fs')
+const http = require('http')
+
+const dir = './logs'
+
+http
+  .createServer((_, res) => {
+    res.setHeader('content-type', 'text/html')
+    if (fs.existsSync(dir)) {
+      const files = fs.readdirSync(dir)
+      res.write('<ul>')
+      res.write(`<li>---------------------------</li>`)
+
+      files.forEach(file => {
+        const log = JSON.parse(fs.readFileSync(`${dir}/${file}`))
+        Object.entries(log).forEach(([key, val]) => {
+          if (key === 'url') {
+            res.write(`<li>${key}: <a href="${val}">${val}</a></li>`)
+          } else {
+            res.write(`<li>${key}: ${val}</li>`)
+          }
+        })
+
+        res.write(`<li>---------------------------</li>`)
+      })
+
+      res.write('</ul>')
+    }
+    res.end()
+  })
+  .listen(3000, function() {
+    console.log('Server started at localhost:3000')
+  })

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "dist",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -32,7 +32,7 @@ gradleEnterprise {
                 def commitDate = 'git --no-pager log -1 --format=%cd --date=local'.execute().text.trim()
                 def fileName = "${buildDate} ${commit}.json"
 
-                file(fileName) << """\
+                new File('build.json') << """\
                     {
                         "branch": "${branch}",
                         "commit": "${commit}",
@@ -42,10 +42,14 @@ gradleEnterprise {
                         "success": ${result.failure == null}
                     }""".stripIndent()
                 
+                def dist = branch == 'logging' ? 'dist' : '../dist'
+
                 copy {
-                    from fileName
-                    into "${branch == 'logging' ? 'dist/' : '../dist/'}logs/"
+                    from file('build.json')
+                    into file("${dist}/logs/")
                 }
+
+                file("${dist}/logs/build.json").renameTo("${dist}/logs/${fileName}")
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,12 +19,17 @@ gradleEnterprise {
         termsOfServiceAgree = 'yes'
         buildFinished { result ->
             buildScanPublished { scan -> 
-                file('build.log') << """\
+                def branch = 'git rev-parse --abbrev-ref HEAD'.execute().text.trim()
+                def commit = 'git rev-parse --verify HEAD'.execute().text.trim()
+                def buildDate = new Date().format('EEE MMM d HH:mm:ss yyyy')
+                def commitDate = 'git --no-pager log -1 --format=%cd --date=local'.execute().text.trim()
+
+                file("${buildDate} ${commit}.log") << """\
                     {
-                        "branch": "${'git rev-parse --abbrev-ref HEAD'.execute().text.trim()}",
-                        "commit": "${'git rev-parse --verify HEAD'.execute().text.trim()}",
-                        "buildDate": "${new Date().format('EEE MMM dd HH:mm:ss yyyy')}",
-                        "commitDate": "${'git --no-pager log -1 --format=%cd --date=local'.execute().text.trim()}",
+                        "branch": "${branch}",
+                        "commit": "${commit}",
+                        "buildDate": "${buildDate}",
+                        "commitDate": "${commitDate}",
                         "url": ${scan.buildScanUri},
                         "success": ${result.failure == null}
                     }""".stripIndent()

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ plugins {
 rootProject.name = 'contint'
 
 def branch = 'git rev-parse --abbrev-ref HEAD'.execute().text.trim()
-if (branch == 'master') {
+if (branch == 'logging') {
     def logs = new File('dist/logs')
     if (!logs.exists()) {
         logs.mkdir()
@@ -30,7 +30,7 @@ gradleEnterprise {
                 def commit = 'git rev-parse --verify HEAD'.execute().text.trim()
                 def buildDate = new Date().format('EEE MMM d HH:mm:ss yyyy')
                 def commitDate = 'git --no-pager log -1 --format=%cd --date=local'.execute().text.trim()
-                def fileName = "${branch == 'master' ? 'dist/' : '../dist/'}logs/${buildDate} ${commit}.json"
+                def fileName = "${buildDate} ${commit}.json"
 
                 file(fileName) << """\
                     {
@@ -41,6 +41,11 @@ gradleEnterprise {
                         "url": "${scan.buildScanUri}",
                         "success": ${result.failure == null}
                     }""".stripIndent()
+                
+                copy {
+                    from fileName
+                    into "${branch == 'logging' ? 'dist/' : '../dist/'}logs/"
+                }
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,24 +13,32 @@ plugins {
 
 rootProject.name = 'contint'
 
+def branch = 'git rev-parse --abbrev-ref HEAD'.execute().text.trim()
+if (branch == 'master') {
+    def logs = new File('dist/logs')
+    if (!logs.exists()) {
+        logs.mkdir()
+    }
+}
+
 gradleEnterprise {
     buildScan {
         termsOfServiceUrl = 'https://gradle.com/terms-of-service'
         termsOfServiceAgree = 'yes'
         buildFinished { result ->
             buildScanPublished { scan -> 
-                def branch = 'git rev-parse --abbrev-ref HEAD'.execute().text.trim()
                 def commit = 'git rev-parse --verify HEAD'.execute().text.trim()
                 def buildDate = new Date().format('EEE MMM d HH:mm:ss yyyy')
                 def commitDate = 'git --no-pager log -1 --format=%cd --date=local'.execute().text.trim()
+                def fileName = "${branch == 'master' ? 'dist/' : '../dist/'}logs/${buildDate} ${commit}.json"
 
-                file("${buildDate} ${commit}.log") << """\
+                file(fileName) << """\
                     {
                         "branch": "${branch}",
                         "commit": "${commit}",
                         "buildDate": "${buildDate}",
                         "commitDate": "${commitDate}",
-                        "url": ${scan.buildScanUri},
+                        "url": "${scan.buildScanUri}",
                         "success": ${result.failure == null}
                     }""".stripIndent()
             }

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,4 +7,28 @@
  * in the user manual at https://docs.gradle.org/6.1.1/userguide/multi_project_builds.html
  */
 
+plugins {
+  id "com.gradle.enterprise" version "3.1.1"
+}
+
 rootProject.name = 'contint'
+
+gradleEnterprise {
+    buildScan {
+        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+        termsOfServiceAgree = 'yes'
+        buildFinished { result ->
+            buildScanPublished { scan -> 
+                file('build.log') << """\
+                    {
+                        "branch": "${'git rev-parse --abbrev-ref HEAD'.execute().text.trim()}",
+                        "commit": "${'git rev-parse --verify HEAD'.execute().text.trim()}",
+                        "buildDate": "${new Date().format('EEE MMM dd HH:mm:ss yyyy')}",
+                        "commitDate": "${'git --no-pager log -1 --format=%cd --date=local'.execute().text.trim()}",
+                        "url": ${scan.buildScanUri},
+                        "success": ${result.failure == null}
+                    }""".stripIndent()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Creates a JSON with build data in the project root folder, as well as a in the dist folder for the Node server to access. This is initiated with `gradle build --scan`. 