### PR TITLE
Fix, cloning is possible from any repo, issue #31

### DIFF
--- a/src/main/java/contint/ContinuousIntegrationServer.java
+++ b/src/main/java/contint/ContinuousIntegrationServer.java
@@ -63,7 +63,7 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         Path tmp_path = Files.createTempDirectory("tmp_git");
 
         try {
-            Git.cloneRepository().setURI("https://github.com/dd2480-12/dd2480-contint.git")
+            Git.cloneRepository().setURI(payload.repository.clone_url)
                     .setDirectory(new File(tmp_path.toString())).setBranchesToClone(Arrays.asList(payload.ref))
                     .setBranch(payload.ref).call();
 

--- a/src/main/java/contint/Payload.java
+++ b/src/main/java/contint/Payload.java
@@ -5,5 +5,9 @@ package contint;
  */
 public class Payload {
 	String ref;
+	Repository repository;
+	
+	class Repository {
+		String clone_url;
+	}
 }
-


### PR DESCRIPTION
The cloning will now be made from "clone_url" given in the json object generated by the webhook, see https://developer.github.com/v3/activity/events/types/#pushevent